### PR TITLE
Add LinkRaster

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,6 @@ pub use gray8::Gray8;
 pub use mask::Mask;
 pub use path::{FillRule,Path2D,PathBuilder,PathOp};
 pub use plotter::Plotter;
-pub use raster::Raster;
+pub use raster::{Raster,LinkRaster};
 pub use rgba8::Rgba8;
 pub use stroker::JoinStyle;

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -8,7 +8,7 @@ use geom::{Transform,Vec2,Vec2w,float_lerp};
 use path::{FillRule,PathOp};
 use mask::Mask;
 use pixel::Format;
-use raster::Raster;
+use raster::{Raster,LinkRaster};
 use stroker::{JoinStyle,Stroke};
 
 /// Plotter for 2D vector paths.
@@ -334,13 +334,21 @@ impl<F: Format> Plotter<F> {
         }
         self.clear_mask()
     }
+    /// Composite mask with a color onto link raster, using "over".
+    ///
+    /// * `clr` Color to composite.
+    /// * `r` The link raster.
+    pub fn over_link(&mut self, clr: F, r: &mut LinkRaster<F>) -> &mut Self {
+        r.over(self.mask(), clr);
+        self.clear_mask()
+    }
     /// Get the mask.
     pub fn mask(&self) -> &Mask {
         &self.mask
     }
     /// Get the raster.
-    pub fn raster(&self) -> Option<&Raster<F>> {
-        self.raster.as_ref()
+    pub fn raster(&mut self) -> Option<&mut Raster<F>> {
+        self.raster.as_mut()
     }
     /// Write the plot to a PNG (portable network graphics) file.
     ///


### PR DESCRIPTION
Added functionality for interfacing with ADI in order to display to a window.  LinkRaster is a type that has the same API as Raster, except that it doesn't own the pixel data.  This is useful if you're writing to a screen and have a pixel buffer already.