### PR TITLE
Compile with WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ criterion = "0.2"
 [[bench]]
 name = "fishyb"
 harness = false
+
+[features]
+default = []
+no-simd = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ name = "fishyb"
 harness = false
 
 [features]
-default = []
-no-simd = []
+default = ["use-simd"]
+use-simd = []

--- a/src/imgbuf.rs
+++ b/src/imgbuf.rs
@@ -3,9 +3,9 @@
 // Copyright (c) 2017-2018  Douglas P Lau
 //
 
-#[cfg(all(target_arch = "x86", not(feature = "no-simd")))]
+#[cfg(all(target_arch = "x86", feature = "use-simd"))]
 use std::arch::x86::*;
-#[cfg(all(target_arch = "x86_64", not(feature = "no-simd")))]
+#[cfg(all(target_arch = "x86_64", feature = "use-simd"))]
 use std::arch::x86_64::*;
 
 /// Accumulate signed area with non-zero fill rule.
@@ -15,7 +15,7 @@ use std::arch::x86_64::*;
 /// * `src` Source buffer.
 pub fn accumulate_non_zero(dst: &mut [u8], src: &mut [i16]) {
     assert!(dst.len() <= src.len());
-    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))] {
+    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), feature = "use-simd"))] {
         if is_x86_feature_detected!("ssse3") {
             unsafe { accumulate_non_zero_x86(dst, src) }
             return;
@@ -40,7 +40,7 @@ fn saturating_cast_i16_u8(v: i16) -> u8 {
 }
 
 /// Accumulate signed area with non-zero fill rule.
-#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), feature = "use-simd"))]
 unsafe fn accumulate_non_zero_x86(dst: &mut [u8], src: &mut [i16]) {
     let zero = _mm_setzero_si128();
     let mut sum = zero;
@@ -69,7 +69,7 @@ unsafe fn accumulate_non_zero_x86(dst: &mut [u8], src: &mut [i16]) {
 }
 
 /// Accumulate signed area sum thru 8 pixels.
-#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), feature = "use-simd"))]
 unsafe fn accumulate_i16x8_x86(mut a: __m128i) -> __m128i {
     //   a7 a6 a5 a4 a3 a2 a1 a0
     // + a3 a2 a1 a0 __ __ __ __
@@ -91,7 +91,7 @@ unsafe fn accumulate_i16x8_x86(mut a: __m128i) -> __m128i {
 /// * `src` Source buffer.
 pub fn accumulate_odd(dst: &mut [u8], src: &mut [i16]) {
     assert!(dst.len() <= src.len());
-    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))] {
+    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), feature = "use-simd"))] {
         if is_x86_feature_detected!("ssse3") {
             unsafe { accumulate_odd_x86(dst, src) }
             return;
@@ -114,7 +114,7 @@ fn accumulate_odd_fallback(dst: &mut [u8], src: &mut [i16]) {
 }
 
 /// Accumulate signed area with even-odd fill rule.
-#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), feature = "use-simd"))]
 unsafe fn accumulate_odd_x86(dst: &mut [u8], src: &mut [i16]) {
     let zero = _mm_setzero_si128();
     let mut sum = zero;

--- a/src/imgbuf.rs
+++ b/src/imgbuf.rs
@@ -3,17 +3,10 @@
 // Copyright (c) 2017-2018  Douglas P Lau
 //
 
-#[cfg(target_arch = "x86")]
+#[cfg(all(target_arch = "x86", not(feature = "no-simd")))]
 use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", not(feature = "no-simd")))]
 use std::arch::x86_64::*;
-
-// Defining this allows easier testing of fallback configuration
-macro_rules! x86 {
-    ($code:block) => {
-        #[cfg(any(target_arch="x86", target_arch="x86_64"))] $code
-    }
-}
 
 /// Accumulate signed area with non-zero fill rule.
 /// Source buffer is zeroed upon return.
@@ -22,12 +15,12 @@ macro_rules! x86 {
 /// * `src` Source buffer.
 pub fn accumulate_non_zero(dst: &mut [u8], src: &mut [i16]) {
     assert!(dst.len() <= src.len());
-    x86!({
+    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))] {
         if is_x86_feature_detected!("ssse3") {
             unsafe { accumulate_non_zero_x86(dst, src) }
             return;
         }
-    });
+    }
     accumulate_non_zero_fallback(dst, src)
 }
 
@@ -47,7 +40,7 @@ fn saturating_cast_i16_u8(v: i16) -> u8 {
 }
 
 /// Accumulate signed area with non-zero fill rule.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn accumulate_non_zero_x86(dst: &mut [u8], src: &mut [i16]) {
     let zero = _mm_setzero_si128();
     let mut sum = zero;
@@ -76,7 +69,7 @@ unsafe fn accumulate_non_zero_x86(dst: &mut [u8], src: &mut [i16]) {
 }
 
 /// Accumulate signed area sum thru 8 pixels.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn accumulate_i16x8_x86(mut a: __m128i) -> __m128i {
     //   a7 a6 a5 a4 a3 a2 a1 a0
     // + a3 a2 a1 a0 __ __ __ __
@@ -98,13 +91,12 @@ unsafe fn accumulate_i16x8_x86(mut a: __m128i) -> __m128i {
 /// * `src` Source buffer.
 pub fn accumulate_odd(dst: &mut [u8], src: &mut [i16]) {
     assert!(dst.len() <= src.len());
-
-    x86!({
+    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))] {
         if is_x86_feature_detected!("ssse3") {
             unsafe { accumulate_odd_x86(dst, src) }
             return;
         }
-    });
+    }
     accumulate_odd_fallback(dst, src)
 }
 
@@ -122,7 +114,7 @@ fn accumulate_odd_fallback(dst: &mut [u8], src: &mut [i16]) {
 }
 
 /// Accumulate signed area with even-odd fill rule.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn accumulate_odd_x86(dst: &mut [u8], src: &mut [i16]) {
     let zero = _mm_setzero_si128();
     let mut sum = zero;

--- a/src/rgba8.rs
+++ b/src/rgba8.rs
@@ -5,17 +5,10 @@
 use png::ColorType;
 use pixel::{PixFmt,lerp_u8};
 
-#[cfg(target_arch = "x86")]
+#[cfg(all(target_arch = "x86", not(feature = "no-simd")))]
 use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", not(feature = "no-simd")))]
 use std::arch::x86_64::*;
-
-// Defining this allows easier testing of fallback configuration
-macro_rules! x86 {
-    ($code:block) => {
-        #[cfg(any(target_arch="x86", target_arch="x86_64"))] $code
-    }
-}
 
 /// 8-bit per channel RGBA [pixel format](trait.PixFmt.html).
 ///
@@ -106,12 +99,12 @@ impl PixFmt for Rgba8 {
     /// * `src` Source color.
     fn over(pix: &mut [Self], mask: &[u8], clr: Self) {
         debug_assert_eq!(pix.len(), mask.len());
-        x86!({
+        #[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))] {
             if is_x86_feature_detected!("ssse3") {
                 unsafe { over_x86(pix, mask, clr) }
                 return;
             }
-        });
+        }
         over_fallback(pix, mask, clr);
     }
     /// Divide alpha (remove premultiplied alpha)
@@ -123,7 +116,7 @@ impl PixFmt for Rgba8 {
 }
 
 /// Composite a color with a mask.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn over_x86(pix: &mut [Rgba8], mask: &[u8], clr: Rgba8) {
     debug_assert_eq!(pix.len(), mask.len());
     let len = pix.len();
@@ -148,7 +141,7 @@ unsafe fn over_x86(pix: &mut [Rgba8], mask: &[u8], clr: Rgba8) {
 }
 
 /// Swizzle alpha mask (xxxxxxxxxxxx3210 => 3333222211110000)
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn swizzle_mask_x86(v: __m128i) -> __m128i {
     _mm_shuffle_epi8(v, _mm_set_epi8(3, 3, 3, 3,
                                      2, 2, 2, 2,
@@ -157,7 +150,7 @@ unsafe fn swizzle_mask_x86(v: __m128i) -> __m128i {
 }
 
 /// Composite packed u8 values using `over`.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn over_alpha_u8x16_x86(t: __m128i, b: __m128i, a: __m128i) -> __m128i {
     // Since alpha can range from 0 to 255 and (t - b) can range from -255 to
     // +255, we would need 17 bits to store the result of a multiplication.
@@ -183,7 +176,7 @@ unsafe fn over_alpha_u8x16_x86(t: __m128i, b: __m128i, a: __m128i) -> __m128i {
 }
 
 /// Scale i16 values (result of "u7" * "i9") into u8.
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(all(any(target_arch="x86", target_arch="x86_64"), not(feature = "no-simd")))]
 unsafe fn scale_i16_to_u8_x86(v: __m128i) -> __m128i {
     // To scale into a u8, we would normally divide by 255.  This is equivalent
     // to: ((v + 1) + (v >> 8)) >> 8


### PR DESCRIPTION
On non-X86 (tested with Web Assembly), this fixes not compiling.  It uses the `cfg()` attribute, rather than the `cfg!` macro.  This should also make it easier to add SIMD support for more targets - just add another macro.